### PR TITLE
Increase speed of finding matched files when exclude is overly broad

### DIFF
--- a/lib/globule.js
+++ b/lib/globule.js
@@ -20,19 +20,32 @@ var globule = exports;
 
 // Process specified wildcard glob patterns or filenames against a
 // callback, excluding and uniquing files in the result set.
-function processPatterns(patterns, fn) {
-  return _.flatten(patterns).reduce(function(result, pattern) {
-    if (pattern.indexOf('!') === 0) {
-      // If the first character is ! all matches via this pattern should be
-      // removed from the result set.
+var processPatterns = function(patterns, options, fn) {
+  // Filepaths to return.
+  var result = [];
+
+  // Iterate over flattened patterns array.
+  _.flatten(patterns).forEach(function(pattern) {
+    // If the first character is ! it should be omitted
+    var exclusion = pattern.indexOf('!') === 0;
+    if (exclusion) {
+      // Strip the ! so that the matching works
       pattern = pattern.slice(1);
-      return _.difference(result, fn(pattern));
-    } else {
-      // Otherwise, add all matching filepaths to the result set.
-      return _.union(result, fn(pattern));
+
+      // Remove any files from the current set that match the exclude pattern
+      var filter_func = minimatch.filter(pattern, options);
+      result = _.filter(result, function(fpath) {
+        return ! filter_func(fpath);
+      });
     }
-  }, []);
-}
+    else {
+      // Find all matching files for this pattern.
+      // And extend the result set
+      result = _.union(result, fn(pattern));
+    }
+  });
+  return result;
+};
 
 // Match a filepath or filepaths against one or more wildcard patterns. Returns
 // all matching filepaths. This behaves just like minimatch.match, but supports
@@ -46,7 +59,7 @@ globule.match = function(patterns, filepaths, options) {
   // Return empty set if there are no patterns or filepaths.
   if (patterns.length === 0 || filepaths.length === 0) { return []; }
   // Return all matching filepaths.
-  return processPatterns(patterns, function(pattern) {
+  return processPatterns(patterns, options, function(pattern) {
     return minimatch.match(filepaths, pattern, options || {});
   });
 };
@@ -73,7 +86,7 @@ globule.find = function() {
     globOptions.cwd = srcBase;
   }
   // Get all matching filepaths.
-  var matches = processPatterns(patterns, function(pattern) {
+  var matches = processPatterns(patterns, options, function(pattern) {
     return glob.sync(pattern, globOptions);
   });
   // If srcBase and prefixBase were specified, prefix srcBase to matched paths.


### PR DESCRIPTION
Long ago it seems our grunt file had patterns like below to find all of the source javascript files but exclude our specs.  

``` javascript
['app/**/*.js', '!**/*_spec.js'] // Note missing app at the front of the exclude to scope the glob.
```

This worked fine until we upgraded to grunt 0.4.  Then our builds got much slower, 0.5 seconds to 10 seconds.  The culprit was the negation of the specs. Grunt currently is running the negation glob against the file system and then removing the excluded files.  This is fine for small systems (or well written excludes) but is slow when you have lots of files (or poorly written globs).  At any rate there is no reason to hit the disk just to exclude file paths which are already known.
- [x] Test suite passes
- [x] Add a test (I did not do this since I could not determine a way to asset that we did not touch disk for the negate step).
