### PR TITLE
Fix issue with globbing exclusions against relative filepaths

### DIFF
--- a/lib/globule.js
+++ b/lib/globule.js
@@ -31,9 +31,9 @@ function processPatterns(patterns, options, fn) {
     }
     // The first character is ! (exclusion). Remove any filepaths from the
     // result set that match this pattern, sans leading !.
-    var filterFn = minimatch.filter(pattern.slice(1), options);
+    var filterFn = minimatch.filter(path.resolve(pattern.slice(1)), options);
     result = _.filter(result, function(filepath) {
-      return !filterFn(filepath);
+      return !filterFn(path.resolve(filepath));
     });
   });
   return result;

--- a/test/globule_test.js
+++ b/test/globule_test.js
@@ -209,6 +209,13 @@ exports['find'] = {
       'inclusion / exclusion order matters');
     test.done();
   },
+  'exclusion against relative paths': function (test) {
+    test.expect(1);
+    test.deepEqual(globule.find('../../fixtures/expand/js/*.js', 'css/**/*.css', '!**/js/**', '!**/css/**/qux.css'), [
+      'css/baz.css'],
+        'exclusion rules should be properly evaluated against relative filepaths');
+    test.done();
+  },
   'options.src': function(test) {
     test.expect(4);
     test.deepEqual(globule.find({src: '**/*.js'}), ['js/bar.js', 'js/foo.js'], 'single pattern argument should match.');


### PR DESCRIPTION
So, was having an issue with grunt-contrib-watch not properly globbing the following exclusion:

``` javascript
//Gruntfile.js
        watch: {                                                               
            js: {                                                              
                files: [                                                       
                    '<%= yeoman.app %>/**/*.js',                               
                    '!**/node_modules/**'                                      
                ],                                                             
                tasks: ['dev']                                                 
            }                                                                  
        },                                                                     

        yeoman: {                                                              
            app: './app',                                                      
            build: './.build',                                                 
            dist: './dist'                                                     
        }             
```

Tracing the problem through grunt-contrib-watch -> gaze -> globule@1.0.0 reveals that neither globule@1.0.0 or @2.0.0 properly handles an exclusion glob when some relative filepath is used -- i.e., it is unable to understand that the following paths 'match':

```
app/js/foo.js //returned from minimatch('**/js/**') in globule#processPatterns
./app/js/foo.js //the filepath that should be matched and excluded. (in results [])
```

This patch fixes the issue by using path.resolve to normalize to absolute paths when running a comparison against the exclusion.  Next steps would be to file bug with gaze to update it's dependency and then grunt-contrib-watch to update gaze.

Unit tests of issue added as well.

Thanks
