### PR TITLE
use glob 5.* to use ignore option

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   ],
   "dependencies": {
     "lodash": "~2.4.1",
-    "glob": "~3.2.7",
+    "glob": "~5.0.14",
     "minimatch": "~0.2.11"
   }
 }

--- a/test/globule_test.js
+++ b/test/globule_test.js
@@ -308,7 +308,7 @@ exports['find'] = {
       ['deep.txt', 'deeper/deeper.txt', 'deeper/deepest/deepest.txt'],
       'should not prefix srcBase to returned paths.');
     test.deepEqual(globule.find(['**/deep*.txt'], {srcBase: 'deep', prefixBase: true}),
-      ['deep/deep.txt', 'deep/deeper/deeper.txt', 'deep/deeper/deepest/deepest.txt'],
+      [path.join('deep', 'deep.txt'), path.join('deep', 'deeper', 'deeper.txt'), path.join('deep', 'deeper', 'deepest', 'deepest.txt')],
       'should prefix srcBase to returned paths.');
     test.done();
   },
@@ -325,6 +325,13 @@ exports['find'] = {
       'non-matching filenames should be returned in result set.');
     test.done();
   },
+	'options.ignore': function(test) {
+    test.expect(1);
+    test.deepEqual(globule.find(['**'], {ignore: ["js/**", "css/**"]}),
+      ['README.md', 'deep', 'deep/deep.txt', 'deep/deeper', 'deep/deeper/deeper.txt', 'deep/deeper/deepest','deep/deeper/deepest/deepest.txt'],
+      'should ignore js and css directories.');
+    test.done();
+  }
 };
 
 exports['mapping'] = {


### PR DESCRIPTION
Starting in glob 4.4 there is an ignore option that can stop traversal down a branch.

globule options are passed straight through to glob, so there is no code change that is needed to take advantage of this, only updating package.json

So this:
```files = globule.find(["**", "!node_modules/**"]);```
Can be replaced by this:
```files = globule.find(["**"], { ignore: ["node_modules/**"]});```

The runtime goes from 4800msecs to 300msecs on my current project.

The negate version does match the node_modules directory itself while the ignore version doesn't.
To make them behave the same do this:
```files = globule.find(["**"], { ignore: ["node_modules/*/**", "node_modules/*"]});```

I created a new test for this.

I'm on windows, so I also needed to change the prefixBase test to use path.join instead of hard coding '/'s. No other tests needed this.
