### PR TITLE
update lodash

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,8 +45,8 @@
     "awesome"
   ],
   "dependencies": {
-    "lodash": "~2.4.1",
     "glob": "~3.2.7",
+    "lodash": "^2.4.2",
     "minimatch": "~0.2.11"
   }
 }


### PR DESCRIPTION
On installing this module I got a warning about the lodash version no longer being maintained. I've updated the version and the tests seem. I've ran the tests in node 5.1.0. I tried to test using node 0.8 but I get the error - `[Error: SSL Error: CERT_UNTRUSTED]` - when trying to install `grunt-cli` or any of the dependencies.