### PR TITLE
fix issue with negating patterns

### DIFF
--- a/lib/globule.js
+++ b/lib/globule.js
@@ -1,4 +1,4 @@
-/*test
+/*
  * globule
  * https://github.com/cowboy/node-globule
  *
@@ -31,10 +31,10 @@ function processPatterns(patterns, options, fn) {
     }
     // The first character is ! (exclusion). Remove any filepaths from the
     // result set that match this pattern, sans leading !.
-    var patt = pattern.slice(1);
-    if(patt.indexOf('(') === 0){//if next character in the glob is a ( assume grouping pattern, and make a positive match all in group by prefixing with a *
-    	patt = '*'+patt;
-    }
+		var patt = pattern.slice(1);
+		if(patt.indexOf('(') === 0){//if next character in the glob is a ( assume grouping pattern, and make a positive match all in group by prefixing with a *
+			patt = '*'+patt;
+		}
     var filterFn = minimatch.filter(patt, options);
     
     result = _.filter(result, function(filepath) {

--- a/lib/globule.js
+++ b/lib/globule.js
@@ -1,4 +1,4 @@
-/*
+/*test
  * globule
  * https://github.com/cowboy/node-globule
  *
@@ -31,7 +31,12 @@ function processPatterns(patterns, options, fn) {
     }
     // The first character is ! (exclusion). Remove any filepaths from the
     // result set that match this pattern, sans leading !.
-    var filterFn = minimatch.filter(pattern.slice(1), options);
+    var patt = pattern.slice(1);
+    if(patt.indexOf('(') === 0){//if next character in the glob is a ( assume grouping pattern, and make a positive match all in group by prefixing with a *
+    	patt = '*'+patt;
+    }
+    var filterFn = minimatch.filter(patt, options);
+    
     result = _.filter(result, function(filepath) {
       return !filterFn(filepath);
     });

--- a/test/globule_test.js
+++ b/test/globule_test.js
@@ -66,9 +66,10 @@ exports['match'] = {
     test.done();
   },
   'exclusion': function(test) {
-    test.expect(5);
+    test.expect(6);
     test.deepEqual(globule.match(['!*.js'], ['foo.js', 'bar.js']), [], 'solitary exclusion should match nothing');
     test.deepEqual(globule.match(['*.js', '!*.js'], ['foo.js', 'bar.js']), [], 'exclusion should cancel match');
+    test.deepEqual(globule.match(['*.js', '!(foo|bar).js'], ['foo.js', 'bar.js', 'baz.js']), ['baz.js'], 'group exlusion should be handled correctly');
     test.deepEqual(globule.match(['*.js', '!f*.js'], ['foo.js', 'bar.js', 'baz.js']),
       ['bar.js', 'baz.js'],
       'partial exclusion should partially cancel match');
@@ -188,7 +189,7 @@ exports['find'] = {
   'exclusion': function(test) {
     test.expect(8);
     test.deepEqual(globule.find(['!js/*.js']), [], 'solitary exclusion should match nothing');
-    test.deepEqual(globule.find(['js/bar.js','!js/bar.js']), [], 'exclusion should negate match');
+    test.deepEqual(globule.find(['js/bar.js','!js/bar.js']), [], 'exclusion should negate match');    
     test.deepEqual(globule.find(['**/*.js', '!js/foo.js']),
       ['js/bar.js'],
       'should omit single file from matched set');


### PR DESCRIPTION
it appeared using a pattern like !(file1|file2) yielded to wrong path selection, this is due to that processPatterns just removes the ! from the pattern. however for the grouping it should also add * as any of the found files should be subtracted from the result