### PR TITLE
Update lodash to 3.10.x, module npm metadata updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: node_js
 node_js:
-  - "0.8"
   - "0.10"
+  - "0.11"
+  - "0.12"
+  - "4"
+  - "5"
 before_script:
   - npm install -g grunt-cli

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2014 "Cowboy" Ben Alman
+Copyright (c) 2016 "Cowboy" Ben Alman
 
 Permission is hereby granted, free of charge, to any person
 obtaining a copy of this software and associated documentation

--- a/README.md
+++ b/README.md
@@ -123,5 +123,5 @@ In lieu of a formal styleguide, take care to maintain the existing coding style.
 2013-04-11 - v0.1.0 - Initial release.
 
 ## License
-Copyright (c) 2014 "Cowboy" Ben Alman  
+Copyright (c) 2016 "Cowboy" Ben Alman
 Licensed under the MIT license.

--- a/lib/globule.js
+++ b/lib/globule.js
@@ -46,8 +46,8 @@ globule.match = function(patterns, filepaths, options) {
   // Return empty set if either patterns or filepaths was omitted.
   if (patterns == null || filepaths == null) { return []; }
   // Normalize patterns and filepaths to flattened arrays.
-  patterns = _.isArray(patterns) ? _.flatten(patterns) : [patterns];
-  filepaths = _.isArray(filepaths) ? _.flatten(filepaths) : [filepaths];
+  patterns = _.isArray(patterns) ? _.flattenDeep(patterns) : [patterns];
+  filepaths = _.isArray(filepaths) ? _.flattenDeep(filepaths) : [filepaths];
   // Return empty set if there are no patterns or filepaths.
   if (patterns.length === 0 || filepaths.length === 0) { return []; }
   // Return all matching filepaths.
@@ -71,9 +71,9 @@ globule.find = function() {
   // arguments. Flatten nested arrays.
   var patterns;
   if (options.src) {
-    patterns = _.isArray(options.src) ? _.flatten(options.src) : [options.src];
+    patterns = _.isArray(options.src) ? _.flattenDeep(options.src) : [options.src];
   } else {
-    patterns = _.flatten(args);
+    patterns = _.flattenDeep(args);
   }
   // Return empty set if there are no patterns.
   if (patterns.length === 0) { return []; }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "globule",
   "description": "An easy-to-use wildcard globbing library.",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "homepage": "https://github.com/cowboy/node-globule",
   "author": {
     "name": "\"Cowboy\" Ben Alman",
@@ -14,15 +14,10 @@
   "bugs": {
     "url": "https://github.com/cowboy/node-globule/issues"
   },
-  "licenses": [
-    {
-      "type": "MIT",
-      "url": "https://github.com/cowboy/node-globule/blob/master/LICENSE-MIT"
-    }
-  ],
+  "license": "MIT",
   "main": "lib/globule",
   "engines": {
-    "node": ">= 0.8.0"
+    "node": ">= 0.10"
   },
   "scripts": {
     "test": "grunt nodeunit"
@@ -45,7 +40,7 @@
     "awesome"
   ],
   "dependencies": {
-    "lodash": "~3.10.1",
+    "lodash": "^3.0.0",
     "glob": "~3.2.7",
     "minimatch": "~0.2.11"
   }

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "awesome"
   ],
   "dependencies": {
-    "lodash": "~2.4.1",
+    "lodash": "~3.10.1",
     "glob": "~3.2.7",
     "minimatch": "~0.2.11"
   }


### PR DESCRIPTION
Made one adjustment to use `flattenDeep`, as that was the only breaking compatibility change based on how you're using the library.

__metadata changes:__

Too many downstream dependencies don't support v0.8 and it's a dead version at this point, so it makes sense to just raise the supported engine value.

Bumping the supported engines is a big enough change to warrant a new minor version, vs a patch version. It's still below 1.x, so semver won't automatically scoop this up and break someone's build.

LICENSE is also updated in package.json and the year is brought up to date.