### PR TITLE
Update minimatch version.

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,6 @@
   "dependencies": {
     "glob": "~7.0.3",
     "lodash": "~4.9.0",
-    "minimatch": "~3.0.0"
+    "minimatch": "^3.0.2"
   }
 }


### PR DESCRIPTION
Fix for ReDoS - https://nodesecurity.io/advisories/118 is patched in 3.0.2