### PR TITLE
chore(package): update minimatch version

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,6 @@
   "dependencies": {
     "glob": "~7.0.3",
     "lodash": "~4.9.0",
-    "minimatch": "~3.0.0"
+    "minimatch": "~3.0.2"
   }
 }


### PR DESCRIPTION
Per https://nodesecurity.io/advisories/118, Regular Expression Denial of Service vulnerability in minimatch <= 3.0.1