### PR TITLE
Update to use micromatch

### DIFF
--- a/lib/globule.js
+++ b/lib/globule.js
@@ -13,7 +13,7 @@ var path = require('path');
 
 var _ = require('lodash');
 var glob = require('glob');
-var minimatch = require('minimatch');
+var micromatch = require('micromatch');
 
 // The module.
 var globule = exports;
@@ -31,7 +31,7 @@ function processPatterns(patterns, options, fn) {
     }
     // The first character is ! (exclusion). Remove any filepaths from the
     // result set that match this pattern, sans leading !.
-    var filterFn = minimatch.filter(pattern.slice(1), options);
+    var filterFn = micromatch.matcher(pattern.slice(1), options);
     result = _.filter(result, function(filepath) {
       return !filterFn(filepath);
     });
@@ -46,7 +46,7 @@ function normalizePath(path) {
 }
 
 // Match a filepath or filepaths against one or more wildcard patterns. Returns
-// all matching filepaths. This behaves just like minimatch.match, but supports
+// all matching filepaths. This behaves just like micromatch.match, but supports
 // any number of patterns.
 globule.match = function(patterns, filepaths, options) {
   // Return empty set if either patterns or filepaths was omitted.
@@ -58,7 +58,7 @@ globule.match = function(patterns, filepaths, options) {
   if (patterns.length === 0 || filepaths.length === 0) { return []; }
   // Return all matching filepaths.
   return processPatterns(patterns, options, function(pattern) {
-    return minimatch.match(filepaths, pattern, options || {});
+    return micromatch.match(filepaths, pattern, options);
   });
 };
 

--- a/package.json
+++ b/package.json
@@ -45,6 +45,6 @@
   "dependencies": {
     "glob": "~7.1.1",
     "lodash": "~4.17.4",
-    "minimatch": "~3.0.2"
+    "micromatch": "^3.1.4"
   }
 }

--- a/test/globule_test.js
+++ b/test/globule_test.js
@@ -66,9 +66,10 @@ exports['match'] = {
     test.done();
   },
   'exclusion': function(test) {
-    test.expect(5);
+    test.expect(6);
     test.deepEqual(globule.match(['!*.js'], ['foo.js', 'bar.js']), [], 'solitary exclusion should match nothing');
     test.deepEqual(globule.match(['*.js', '!*.js'], ['foo.js', 'bar.js']), [], 'exclusion should cancel match');
+    test.deepEqual(globule.match(['*.js', '!(foo|bar).js'], ['foo.js', 'bar.js', 'baz.js']), ['baz.js'], 'group exlusion should be handled correctly');
     test.deepEqual(globule.match(['*.js', '!f*.js'], ['foo.js', 'bar.js', 'baz.js']),
       ['bar.js', 'baz.js'],
       'partial exclusion should partially cancel match');


### PR DESCRIPTION
## Description

This PR is to use [micromatch](https://github.com/micromatch/micromatch) instead of minimatch.

This change addresses the performance and safety issues that have been found in minimatch. For more general information on why to use micromatch, [this section goes over the features](https://github.com/micromatch/micromatch#why-use-micromatch). Also, the [braces readme](https://github.com/micromatch/braces#why-use-braces) has more information about why it's safer.

## Additional information

Using micromatch resolves https://github.com/cowboy/node-globule/pull/25, since micromatch has more complete extglob support. A test has been added for this use case.

You can also close https://github.com/cowboy/node-globule/issues/10, since `{ignore: ['**/node_modules/**']}` will achieve the desired result. 