### PR TITLE
Bump glob and minimatch to grab security fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,8 +43,8 @@
     "awesome"
   ],
   "dependencies": {
-    "glob": "~7.1.1",
+    "glob": "~7.1.3",
     "lodash": "~4.17.10",
-    "minimatch": "~3.0.2"
+    "minimatch": "~3.0.4"
   }
 }


### PR DESCRIPTION
Both of these new versions capture updated dependencies that fix security audits found in `npm audit` and should be changed accordingly