### PR TITLE
Fix CVE-2019-10744

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   ],
   "dependencies": {
     "glob": "~7.1.1",
-    "lodash": "~4.17.10",
+    "lodash": "~4.17.21",
     "minimatch": "~3.0.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   ],
   "dependencies": {
     "glob": "~7.1.1",
-    "lodash": "~4.17.21",
+    "lodash": "^4.17.21",
     "minimatch": "~3.0.2"
   }
 }


### PR DESCRIPTION
Update LoDash sub-dependency to address https://nvd.nist.gov/vuln/detail/CVE-2019-10744